### PR TITLE
Update to support newer log4js versions

### DIFF
--- a/lib/protractorAppender.js
+++ b/lib/protractorAppender.js
@@ -28,8 +28,8 @@ function resolveAllPromises(dataParts) {
   return global.protractor.promise.fullyResolved(promises);
 }
 
-function configure(config) {
-  return protractorAppender(consoleAppender.configure(config));
+function configure(config, layouts) {
+  return protractorAppender(consoleAppender.configure(config, layouts));
 }
 
 exports.appender = protractorAppender;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "selenium-webdriver": "^2.46.1"
   },
   "dependencies": {
-    "log4js": "^0.6.26"
+    "log4js": "^0.6.26 - 3"
   }
 }


### PR DESCRIPTION
I would like to use new version of log4js in my project (e.g. because of some features like Typescript typings), but this appender has hardcoded reference to and older version and it fails at runtime with newer version. This PR is intended to introduce the necessary change in order to make it compatible with more recent versions of log4js.

For log4js v2 and v3, there is new parameter 'layouts' expected by console configure() function, which was added to configure() here.
For older release (v0 and v1) this parameter does not exist, but the change is backward-compatible (because extra parameter is ignored by JS).

I have changed version range to include the log4js v1, v2 and v3 (newest). I have executed tests with the appender once for each distinct major release.