### PR TITLE
Add handling for undefined value

### DIFF
--- a/lib/protractorAppender.js
+++ b/lib/protractorAppender.js
@@ -19,9 +19,7 @@ function protractorAppender(consoleLog) {
 
 function resolveAllPromises(dataParts) {
   var promises = dataParts.map(function (value) {
-    if (value === undefined) {
-      return global.protractor.promise.when(value);
-    } else if (value.then) {
+    if (!!value && value.then) {
       return value;
     } else {
       return global.protractor.promise.when(value);

--- a/lib/protractorAppender.js
+++ b/lib/protractorAppender.js
@@ -19,7 +19,9 @@ function protractorAppender(consoleLog) {
 
 function resolveAllPromises(dataParts) {
   var promises = dataParts.map(function (value) {
-    if (value.then) {
+    if (value === undefined) {
+      return global.protractor.promise.when(value);
+    } else if (value.then) {
       return value;
     } else {
       return global.protractor.promise.when(value);

--- a/test/protractorAppender-spec.js
+++ b/test/protractorAppender-spec.js
@@ -80,5 +80,18 @@ describe('protractorAppender', function () {
         deferred.fulfill('World');
       }, 50);
     });
+
+    it('should handle undefined in the log event', function (done) {
+      global.browser = protractorMock;
+      event.data.push(undefined);
+
+      appender(event).then(function () {
+        expect(consoleMock).toHaveBeenCalledWith({
+          data: ['Hello', undefined],
+          startTime: jasmine.any(Date)
+        });
+        done();
+      });
+    });
   });
 });

--- a/test/protractorAppender-spec.js
+++ b/test/protractorAppender-spec.js
@@ -93,5 +93,18 @@ describe('protractorAppender', function () {
         done();
       });
     });
+
+    it('should handle null value in the log event', function (done) {
+      global.browser = protractorMock;
+      event.data.push(null);
+
+      appender(event).then(function () {
+        expect(consoleMock).toHaveBeenCalledWith({
+          data: ['Hello', null],
+          startTime: jasmine.any(Date)
+        });
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
The appender shouldn't blow up on `undefined` value, it should pass this value to the console logger.